### PR TITLE
Deleted hirak/prestissimo package from Dockerfile

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -31,7 +31,5 @@ COPY ./xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 RUN echo "xdebug.remote_host=${HOST}" >> /usr/local/etc/php/conf.d/xdebug.ini
 
 USER appuser
-RUN composer global require "hirak/prestissimo:^0.3" --prefer-dist --no-progress --no-suggest --optimize-autoloader --classmap-authoritative \
-	&& composer clear-cache
 
 WORKDIR /app


### PR DESCRIPTION
Deleted hirak/prestissimo package from Dockerfile, in order to avoid composer error during 'make build' process of the project. According to hirak/prestissimo repo docs, this plugin is now not necessary as Composer 2 if faster than the previous version.